### PR TITLE
Make Injector/Publisher usable with just request/response (no wsgi).

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,10 @@ CHANGES
 
 - Added Python 3 compatibility. Fixes issue #25.
 
+- The injector and the publisher can now also be used by providing request and
+  response. This enables third-party frameworks to write integrations that 
+  don't require wrapping of the wsgi instance.
+
 0.5 (2014-09-24)
 ================
 

--- a/bowerstatic/injector.py
+++ b/bowerstatic/injector.py
@@ -10,9 +10,7 @@ class Injector(object):
         self.bower = bower
         self.wsgi = wsgi
 
-    @webob.dec.wsgify
-    def __call__(self, request):
-        response = request.get_response(self.wsgi)
+    def inject(self, request, response):
         if request.method not in METHODS:
             return response
         if response.content_type.lower() not in CONTENT_TYPES:
@@ -26,3 +24,7 @@ class Injector(object):
             b'</head>', b''.join((inclusions.render().encode(), b'</head>')))
         response.write(body)
         return response
+
+    @webob.dec.wsgify
+    def __call__(self, request):
+        return self.inject(request, request.get_response(self.wsgi))

--- a/bowerstatic/publisher.py
+++ b/bowerstatic/publisher.py
@@ -17,13 +17,12 @@ class Publisher(object):
         self.bower = bower
         self.wsgi = wsgi
 
-    @webob.dec.wsgify
-    def __call__(self, request):
+    def publish(self, request, response):
         # first segment should be publisher signature
         publisher_signature = request.path_info_peek()
         # pass through to underlying WSGI app
         if publisher_signature != self.bower.publisher_signature:
-            return request.get_response(self.wsgi)
+            return response
         request.path_info_pop()
         # next segment is BowerComponents name
         bower_components_name = request.path_info_pop()
@@ -54,3 +53,7 @@ class Publisher(object):
             response.expires = time.time() + FOREVER
         # XXX do we really want to rely on mimetype guessing?
         return response
+
+    @webob.dec.wsgify
+    def __call__(self, request):
+        return self.publish(request, request.get_response(self.wsgi))

--- a/doc/integrating.rst
+++ b/doc/integrating.rst
@@ -313,3 +313,15 @@ is equivalent to this::
   app = bower.publisher(bower.injector(my_wsgi_app))
 
 
+Using the Publisher and Injector without WSGI
+---------------------------------------------
+
+The Injector/Publisher may be used without a WSGI instance. This is useful
+for integration into other web frameworks::
+
+    injector = bower.injector(wsgi=None)
+    publisher = bower.publisher(wsgi=None)
+
+    response = publisher.publish(request, injector.inject(request, response))
+
+All that is required is a request and a response.


### PR DESCRIPTION
This is a requirement for https://github.com/morepath/more.static/issues/3.
