### PR TITLE
Do not crash when a version information is missing in bower.json

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ CHANGES
 0.5 (unreleased)
 ================
 
-- Nothing changed yet.
+- Do not crash when a version information is missing in bower.json.
 
 
 0.4 (2014-09-08)

--- a/bowerstatic/core.py
+++ b/bowerstatic/core.py
@@ -109,7 +109,7 @@ class ComponentCollection(object):
         dependencies = data.get('dependencies')
         if dependencies is None:
             dependencies = {}
-        version = version or data['version']
+        version = version or data.get('version')
         return Component(self.bower,
                          self,
                          path,


### PR DESCRIPTION
Currently `bowerstatic` fails hard when a version information is missing.

I'm not absolutely sure why that happens, but I have seen it for the generated `.bower.json` file of [BlockUI 2.65](https://github.com/malsup/blockui/tree/2.65).

In any case, bowerstatic should not fail hard.