### PR TITLE
UnicodeDecodeError if `render_favicon` is used

### DIFF
--- a/bowerstatic/renderer.py
+++ b/bowerstatic/renderer.py
@@ -35,8 +35,10 @@ class Renderer(object):
 def make_renderer(renderer):
     if isinstance(renderer, string_types):
         def string_renderer(resource):
-            return renderer.format(url=resource.url(),
-                                   content=resource.content())
+            if '{content}' in renderer:
+                return renderer.format(content=resource.content())
+            else:
+                return renderer.format(url=resource.url())
         return string_renderer
 
     if callable(renderer):


### PR DESCRIPTION
The patch solves the problem, but maybe there are better possibilities to differentiate between inline and url renderer.