### PR TITLE
Make sure path is normalised

### DIFF
--- a/bowerstatic/core.py
+++ b/bowerstatic/core.py
@@ -223,7 +223,7 @@ class Component(object):
                  path, name, version, main, dependencies, autoversion):
         self.bower = bower
         self.component_collection = component_collection
-        self.path = path
+        self.path = os.path.normpath(path)
         self.name = name
         self._version = version
         self.main = main


### PR DESCRIPTION
On Windows, I have the situation where this path variable has forward and backward slashes in it. This makes sure all the slashes are the same and the correct type.

I have tried this locally and it works. Without this fix, bowerstatic doesn't work for me at all.