### PR TITLE
Do not crash when a version information is missing in bower.json

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ CHANGES
 0.10 (unreleased)
 =================
 
-- Nothing changed yet.
+- Do not crash when a version information is missing in bower.json.
 
 
 0.9 (2015-06-23)

--- a/bowerstatic/core.py
+++ b/bowerstatic/core.py
@@ -115,7 +115,7 @@ class ComponentCollection(object):
         dependencies = data.get('dependencies')
         if dependencies is None:
             dependencies = {}
-        version = version or data['version']
+        version = version or data.get('version')
         return Component(self.bower,
                          self,
                          path,

--- a/bowerstatic/core.py
+++ b/bowerstatic/core.py
@@ -115,7 +115,14 @@ class ComponentCollection(object):
         dependencies = data.get('dependencies')
         if dependencies is None:
             dependencies = {}
-        version = version or data.get('version')
+        if not version:
+            version = data.get('_release')
+        if not version:
+            try:
+                version = data['version']
+            except KeyError:
+                raise ValueError('Missing _release and version in {}'.format(
+                    path))
         return Component(self.bower,
                          self,
                          path,

--- a/bowerstatic/tests/bower_components/missing-version-in-dot-bower-json/.bower.json
+++ b/bowerstatic/tests/bower_components/missing-version-in-dot-bower-json/.bower.json
@@ -1,0 +1,5 @@
+{
+  "name": "missing-version-in-dot-bower-json",
+  "_release": "1.0",
+  "main": "example.js"
+}

--- a/bowerstatic/tests/bower_components/missing-version-in-dot-bower-json/bower.json
+++ b/bowerstatic/tests/bower_components/missing-version-in-dot-bower-json/bower.json
@@ -1,0 +1,4 @@
+{
+  "name": "missing-version-in-dot-bower-json",
+  "version": "2.65"
+}

--- a/bowerstatic/tests/bower_components/missing-version-in-dot-bower-json/example.js
+++ b/bowerstatic/tests/bower_components/missing-version-in-dot-bower-json/example.js
@@ -1,0 +1,1 @@
+example.js

--- a/bowerstatic/tests/local_component_missing_version/bower.json
+++ b/bowerstatic/tests/local_component_missing_version/bower.json
@@ -1,0 +1,3 @@
+{
+  "name": "local_component_missing_version"
+}

--- a/bowerstatic/tests/test_injector.py
+++ b/bowerstatic/tests/test_injector.py
@@ -275,6 +275,35 @@ def test_injector_endpoint_depends_on_main_missing():
         b'2.1.1/resource.js"></script></head><body>Hello!</body></html>')
 
 
+def test_injector_missing_version_bower_components():
+    bower = bowerstatic.Bower()
+
+    components = bower.components('components', os.path.join(
+        os.path.dirname(__file__), 'bower_components'))
+
+    def wsgi(environ, start_response):
+        start_response('200 OK', [('Content-Type', 'text/html;charset=UTF-8')])
+        include = components.includer(environ)
+        include('missing-version-in-dot-bower-json')
+        return [b'<html><head></head><body>Hello!</body></html>']
+
+    injector = bower.injector(wsgi)
+
+    c = Client(injector)
+
+    response = c.get('/')
+
+    # without a main, it should just include nothing
+    assert response.body == (
+        b'<html><head>'
+        b'<script type="text/javascript" '
+        b'src="/bowerstatic/components/missing-version-in-dot-bower-json/'
+        b'1.0/example.js"></script>'
+        b'</head><body>Hello!</body></html>')
+
+
+
+
 def test_injector_endpoint_multiple_mains():
     bower = bowerstatic.Bower()
 

--- a/bowerstatic/tests/test_local.py
+++ b/bowerstatic/tests/test_local.py
@@ -217,6 +217,23 @@ def test_local_bower_json_dependencies():
         b'</head><body>Hello!</body></html>')
 
 
+def test_local_with_missing_version():
+    bower = bowerstatic.Bower()
+
+    components = bower.components('components', os.path.join(
+        os.path.dirname(__file__), 'bower_components'))
+
+    local = bower.local_components('local', components)
+
+    path = os.path.join(
+        os.path.dirname(__file__), 'local_component_missing_version')
+
+    with pytest.raises(ValueError) as err:
+        local.component(path, version=None)
+    assert str(err.value).startswith('Missing _release and version in')
+    assert str(err.value).endswith('/tests/local_component_missing_version')
+
+
 # FIXME: strictly speaking Linux ext3 also has a failing bug here,
 # but I don't know how to reliably detect whether the filesystem has
 # only second granularity so this will have to do


### PR DESCRIPTION
This is a second attempt to fix #45. I implemented the suggestions from #45 and added tests.
A missing version for local components still crashes but now with a better error message.
For bower components ``_release`` is preferred over ``version``. (``version`` is missing in ``.bower.json`` if there is not git tag in the repositiory matching the version number in ``bower.json``, so the commit ID is used for ``_release``.)