### PR TITLE
module_relative_path sometimes returns a relative path

### DIFF
--- a/bowerstatic/tests/test_core.py
+++ b/bowerstatic/tests/test_core.py
@@ -52,6 +52,17 @@ def test_relative_path_bower_components():
         os.path.dirname(__file__), 'bower_components') == components.path
 
 
+def test_module_relative_path_is_absolute(monkeypatch, tmpdir):
+    monkeypatch.chdir(tmpdir)
+    monkeypatch.syspath_prepend('.')
+
+    with open('example.py', 'wt') as f:
+        f.write("path = __import__('bowerstatic').module_relative_path('bower_components')\n")
+
+    import os, example
+    assert os.path.isabs(example.path)
+
+
 def test_relative_path_local_components():
     bower = bowerstatic.Bower()
 

--- a/bowerstatic/utility.py
+++ b/bowerstatic/utility.py
@@ -9,5 +9,5 @@ def module_relative_path(path):
         return path
 
     calling_file = inspect.stack()[1][1]
-    calling_dir = os.path.split(calling_file)[0]
+    calling_dir = os.path.abspath(os.path.dirname(calling_file))
     return os.path.join(calling_dir, path)


### PR DESCRIPTION
The current implementation of bowserstatic.module_relative_path assumes that the filename retrieved by stack inspection is absolute. This is not necessarily the case as the test case that I added shows.

A very simple fix is provided.